### PR TITLE
Do not attempt to match newline characters

### DIFF
--- a/grammars/pixie.cson
+++ b/grammars/pixie.cson
@@ -64,7 +64,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.pixie'
-    'match': '(;).*$\\n?'
+    'match': '(;).*$'
     'name': 'comment.line.semicolon.pixie'
   'constants':
     'patterns': [
@@ -185,15 +185,13 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.pixie'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
+    'end': '(\\))$|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.trailing.pixie'
       '2':
-        'name': 'meta.after-expression.pixie'
-      '3':
         'name': 'punctuation.section.expression.end.trailing.pixie'
-      '4':
+      '3':
         'name': 'punctuation.section.expression.end.pixie'
     'name': 'meta.quoted-expression.pixie'
     'patterns': [
@@ -235,15 +233,13 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.section.expression.begin.pixie'
-    'end': '(\\))(\\n)|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
+    'end': '(\\))$|(\\)(?=[\\}\\]\\)\\s]*(?:;|$)))|(\\))'
     'endCaptures':
       '1':
         'name': 'punctuation.section.expression.end.trailing.pixie'
       '2':
-        'name': 'meta.after-expression.pixie'
-      '3':
         'name': 'punctuation.section.expression.end.trailing.pixie'
-      '4':
+      '3':
         'name': 'punctuation.section.expression.end.pixie'
     'name': 'meta.expression.pixie'
     'patterns': [
@@ -307,7 +303,7 @@
     'captures':
       '1':
         'name': 'punctuation.definition.comment.shebang.pixie'
-    'match': '^(\\#!).*$\\n?'
+    'match': '^(\\#!).*$'
     'name': 'comment.line.semicolon.pixie'
   'string':
     'begin': '(?<!\\\\)(")'

--- a/spec/grammar-spec.coffee
+++ b/spec/grammar-spec.coffee
@@ -145,7 +145,7 @@ describe "Pixie grammar", ->
     # Entire expression on one line.
     {tokens} = grammar.tokenizeLine "#{startsWith}foo, bar#{endsWith}"
 
-    [start, mid..., end, after] = tokens
+    [start, mid..., end, whitespace] = tokens
 
     expect(start).toEqual value: startsWith, scopes: ["source.pixie", "meta.#{metaScope}.pixie", "punctuation.section.#{puncScope}.begin.pixie"]
     expect(end).toEqual value: endsWith, scopes: ["source.pixie", "meta.#{metaScope}.pixie", "punctuation.section.#{puncScope}.end.trailing.pixie"]
@@ -156,14 +156,14 @@ describe "Pixie grammar", ->
     # Expression broken over multiple lines.
     tokens = grammar.tokenizeLines("#{startsWith}foo\n bar#{endsWith}")
 
-    [start, mid..., after] = tokens[0]
+    [start, mid...] = tokens[0]
 
     expect(start).toEqual value: startsWith, scopes: ["source.pixie", "meta.#{metaScope}.pixie", "punctuation.section.#{puncScope}.begin.pixie"]
 
     for token in mid
       expect(token.scopes.slice(0, 2)).toEqual ["source.pixie", "meta.#{metaScope}.pixie"]
 
-    [mid..., end, after] = tokens[1]
+    [mid..., end] = tokens[1]
 
     expect(end).toEqual value: endsWith, scopes: ["source.pixie", "meta.#{metaScope}.pixie", "punctuation.section.#{puncScope}.end.trailing.pixie"]
 


### PR DESCRIPTION
This PR replaces all \n end matches with $. The two are nearly identical, with the only difference being that $ does not create a zero-width match at the end of the line. These changes are mainly required due to atom/first-mate#100, as newlines are no longer added to the last line of the file. Therefore, this change is simply a backwards-compatible change to ensure that language-pixie continues working as before on Atom 1.22+.

/cc @Ingramz

Refs atom/atom#15729